### PR TITLE
Fix: Google Analytics never loaded (GA4 receiving no data)

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,11 +2,17 @@ import React, { useEffect } from 'react';
 import 'prismjs/themes/prism-tomorrow.css';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
+import Script from 'next/script';
 import '../styles/globals.scss';
 import { DefaultSeo } from 'next-seo';
 import Layout from '../components/Layout';
 import SEO from '../next-seo.config';
 import * as ga from '../lib/analytics';
+
+const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || 'G-HM718Q7C20';
+const shouldLoadAnalytics = process.env.NODE_ENV === 'production'
+  && GA_MEASUREMENT_ID
+  && GA_MEASUREMENT_ID !== 'G-XXXXXXXXXX';
 
 function MyApp({ Component, pageProps }) {
   const router = useRouter();
@@ -37,6 +43,40 @@ function MyApp({ Component, pageProps }) {
         <meta charSet="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       </Head>
+      {shouldLoadAnalytics && (
+        <>
+          <Script
+            strategy="afterInteractive"
+            src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+          />
+          <Script
+            id="google-analytics"
+            strategy="afterInteractive"
+            dangerouslySetInnerHTML={{
+              __html: `
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+
+                // Privacy-compliant defaults; consent is granted via CookieConsent.
+                gtag('consent', 'default', {
+                  analytics_storage: 'denied',
+                  ad_storage: 'denied',
+                  wait_for_update: 500
+                });
+
+                gtag('js', new Date());
+                gtag('config', '${GA_MEASUREMENT_ID}', {
+                  anonymize_ip: true,
+                  allow_google_signals: false,
+                  allow_ad_personalization_signals: false,
+                  send_page_view: false,
+                  cookie_flags: 'SameSite=Strict;Secure'
+                });
+              `,
+            }}
+          />
+        </>
+      )}
       <Component {...pageProps} />
     </Layout>
   );

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -9,11 +9,6 @@ import Layout from '../components/Layout';
 import SEO from '../next-seo.config';
 import * as ga from '../lib/analytics';
 
-const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || 'G-HM718Q7C20';
-const shouldLoadAnalytics = process.env.NODE_ENV === 'production'
-  && GA_MEASUREMENT_ID
-  && GA_MEASUREMENT_ID !== 'G-XXXXXXXXXX';
-
 function MyApp({ Component, pageProps }) {
   const router = useRouter();
 
@@ -43,11 +38,11 @@ function MyApp({ Component, pageProps }) {
         <meta charSet="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       </Head>
-      {shouldLoadAnalytics && (
+      {ga.isAnalyticsEnabled && (
         <>
           <Script
             strategy="afterInteractive"
-            src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+            src={`https://www.googletagmanager.com/gtag/js?id=${ga.GA_MEASUREMENT_ID}`}
           />
           <Script
             id="google-analytics"
@@ -57,20 +52,13 @@ function MyApp({ Component, pageProps }) {
                 window.dataLayer = window.dataLayer || [];
                 function gtag(){dataLayer.push(arguments);}
 
-                // Privacy-compliant defaults; consent is granted via CookieConsent.
+                // Set privacy-compliant consent defaults before gtag.js loads;
+                // gtag('js')/gtag('config') is handled by ga.initGA(). Consent is
+                // granted later via CookieConsent.
                 gtag('consent', 'default', {
                   analytics_storage: 'denied',
                   ad_storage: 'denied',
                   wait_for_update: 500
-                });
-
-                gtag('js', new Date());
-                gtag('config', '${GA_MEASUREMENT_ID}', {
-                  anonymize_ip: true,
-                  allow_google_signals: false,
-                  allow_ad_personalization_signals: false,
-                  send_page_view: false,
-                  cookie_flags: 'SameSite=Strict;Secure'
                 });
               `,
             }}

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -15,52 +15,14 @@ class MyDocument extends Document {
   }
 
   render() {
-    const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || 'G-HM718Q7C20';
     const GOOGLE_ADS_CLIENT_ID = process.env.NEXT_PUBLIC_ADSENSE_PUBLISHER_ID;
     const isProduction = process.env.NODE_ENV === 'production';
-    const shouldLoadAnalytics = isProduction && GA_MEASUREMENT_ID && GA_MEASUREMENT_ID !== 'G-XXXXXXXXXX';
 
     return (
       <Html>
         <Head>
-          {/* Google Analytics - Only load in production with valid ID */}
-          {/* {shouldLoadAnalytics && (
-            <>
-              <Script
-                strategy="afterInteractive"
-                src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
-              />
-              <Script
-                id="google-analytics"
-                strategy="afterInteractive"
-                dangerouslySetInnerHTML={{
-                  __html: `
-                    window.dataLayer = window.dataLayer || [];
-                    function gtag(){dataLayer.push(arguments);}
-
-                    // Initialize with privacy-compliant defaults
-                    gtag('consent', 'default', {
-                      analytics_storage: 'denied',
-                      ad_storage: 'denied',
-                      wait_for_update: 500
-                    });
-
-                    gtag('js', new Date());
-                    gtag('config', '${GA_MEASUREMENT_ID}', {
-                      // Privacy settings
-                      anonymize_ip: true,
-                      allow_google_signals: false,
-                      allow_ad_personalization_signals: false,
-                      // Performance settings
-                      send_page_view: false,
-                      // Cookie settings
-                      cookie_flags: 'SameSite=Strict;Secure'
-                    });
-                  `,
-                }}
-              />
-            </>
-          )} */}
+          {/* Google Analytics lives in _app.js: next/script afterInteractive does not
+              reliably inject from _document. */}
 
           {/* Google Ads - Only load if client ID is provided */}
           {isProduction && GOOGLE_ADS_CLIENT_ID && GOOGLE_ADS_CLIENT_ID !== 'ca-pub-XXXXXXXXX' && (


### PR DESCRIPTION
## Problem

GA4 reported it had **never received any data** from the site (`Todavía no se han recibido datos de tu sitio web`). This was site-wide, not specific to the conference page.

## Root cause

Two issues, in order:

1. **The gtag.js scripts were commented out** in `pages/_document.js`. So `window.gtag` never existed and every `initGA` / `pageview` / `event` call in `lib/analytics.js` silently hit its `isGtagAvailable()` guard and no-opped.

2. **Uncommenting alone did not fix it.** `next/script` with `strategy="afterInteractive"` does not reliably inject when placed in `_document`. Verified in a real browser (Cypress): after uncommenting + a production build, `window.gtag` was still `undefined`.

## Fix

- Move the GA scripts to `pages/_app.js` (the documented placement for `afterInteractive`). `window.gtag` is now defined.
- Remove the dead, non-working block from `_document.js`.

## Verification

Confirmed in a real browser against a local production build:
- ✅ `gtag.js` loads and `window.gtag` is a function.
- ✅ Clicking **Accept** on the cookie banner pushes a `consent update` with `analytics_storage: 'granted'` into `dataLayer`, after which hits flow.

Jest 45/45, lint clean.

## Follow-up (action needed)

`NEXT_PUBLIC_GA_MEASUREMENT_ID` is **not set in `.env`**; the code falls back to the hardcoded `G-HM718Q7C20`, so it works — but please confirm that env var is set in **Vercel** for robustness.

Note: analytics is consent-gated (Consent Mode defaults to denied). Real-time data only appears after a visitor clicks **Accept** on the cookie banner. To self-test, visit the live site, accept cookies, then check GA4 Realtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)