### PR TITLE
Fix: immutable state + server error feedback in conference form

### DIFF
--- a/__tests__/components/ConferenceFeedbackForm.test.jsx
+++ b/__tests__/components/ConferenceFeedbackForm.test.jsx
@@ -40,6 +40,37 @@ describe('ConferenceFeedbackForm', () => {
     expect(submitConferenceFeedback).not.toHaveBeenCalled();
   });
 
+  it('shows a server error message when the API returns an error', async () => {
+    submitConferenceFeedback.mockResolvedValue({ error: 'La calificación debe estar entre 1 y 5.' });
+    render(<ConferenceFeedbackForm slug="react-conf" conferenceName="React Conf" />);
+    fill('Ada', 'Great talk!');
+    fireEvent.click(screen.getByText('Enviar Feedback'));
+
+    expect(await screen.findByText('La calificación debe estar entre 1 y 5.')).toBeInTheDocument();
+  });
+
+  it('shows a generic error message when the submission rejects', async () => {
+    submitConferenceFeedback.mockRejectedValue(new Error('network down'));
+    render(<ConferenceFeedbackForm slug="react-conf" conferenceName="React Conf" />);
+    fill('Ada', 'Great talk!');
+    fireEvent.click(screen.getByText('Enviar Feedback'));
+
+    expect(
+      await screen.findByText('No se pudo enviar el feedback. Intenta de nuevo.'),
+    ).toBeInTheDocument();
+  });
+
+  it('clears the comment field after a successful submission', async () => {
+    render(<ConferenceFeedbackForm slug="react-conf" conferenceName="React Conf" />);
+    fill('Ada', 'Great talk!');
+    const comment = screen.getByPlaceholderText(/Qué te pareció la charla/i);
+    expect(comment).toHaveValue('Great talk!');
+
+    fireEvent.click(screen.getByText('Enviar Feedback'));
+
+    await waitFor(() => expect(comment).toHaveValue(''));
+  });
+
   it('submits a parsed integer score plus honeypot and timing fields', async () => {
     render(<ConferenceFeedbackForm slug="react-conf" conferenceName="React Conf" />);
     fill('Ada', 'Great talk!');

--- a/components/ConferenceFeedbackForm.jsx
+++ b/components/ConferenceFeedbackForm.jsx
@@ -5,7 +5,7 @@ import { getReadableTextColor } from '../lib/color';
 
 function ConferenceFeedbackForm({ slug, conferenceName, themeColor }) {
   const buttonColor = themeColor || '#db2777'; // pink-600 default
-  const [error, setError] = useState(false);
+  const [error, setError] = useState('');
   const [localStorage, setLocalStorage] = useState(null);
   const [showSuccessMessage, setShowSuccessMessage] = useState(false);
   const [renderedAt, setRenderedAt] = useState(null);
@@ -46,10 +46,10 @@ function ConferenceFeedbackForm({ slug, conferenceName, themeColor }) {
   };
 
   const handlePostSubmission = () => {
-    setError(false);
+    setError('');
     const { userName, comment, score, storeData } = formData;
     if (!userName || !comment || !score) {
-      setError(true);
+      setError('Todos los campos son obligatorios.');
       return;
     }
     const feedbackObj = {
@@ -68,29 +68,33 @@ function ConferenceFeedbackForm({ slug, conferenceName, themeColor }) {
     }
 
     submitConferenceFeedback(feedbackObj).then((res) => {
-      if (res.createConferenceFeedback) {
-        if (!storeData) {
-          formData.userName = null;
-        }
-        formData.comment = '';
+      if (res && res.createConferenceFeedback) {
+        // Reset the comment (and the name unless the user chose to remember it),
+        // updating state immutably rather than mutating formData directly.
         setFormData((prevState) => ({
           ...prevState,
-          ...formData,
+          userName: storeData ? prevState.userName : null,
+          comment: '',
         }));
         setShowSuccessMessage(true);
 
         // Track feedback submission in GA4
         event({
-            action: 'submit_conference_feedback',
-            category: 'conference_landing',
-            label: conferenceName,
-            value: parseInt(score, 10)
+          action: 'submit_conference_feedback',
+          category: 'conference_landing',
+          label: conferenceName,
+          value: parseInt(score, 10),
         });
 
         setTimeout(() => {
           setShowSuccessMessage(false);
         }, 5000);
+      } else {
+        // Server rejected the submission (e.g. validation error).
+        setError(res?.error || 'No se pudo enviar el feedback. Intenta de nuevo.');
       }
+    }).catch(() => {
+      setError('No se pudo enviar el feedback. Intenta de nuevo.');
     });
   };
 
@@ -168,7 +172,7 @@ function ConferenceFeedbackForm({ slug, conferenceName, themeColor }) {
       </div>
       {error && (
         <p className="text-xs text-red-500">
-          Todos los campos son obligatorios.
+          {error}
         </p>
       )}
       <div className="mt-8">


### PR DESCRIPTION
## Summary

Addresses PR #9 review feedback on `ConferenceFeedbackForm`.

### 1. Direct state mutation (React anti-pattern)
`handlePostSubmission` mutated `formData` directly before calling `setFormData`:
```js
formData.userName = null;
formData.comment = '';
setFormData((prev) => ({ ...prev, ...formData }));
```
Now the fields are reset **immutably** inside the `setFormData` updater.

### 2. No feedback on server errors
The form silently ignored API errors. The boolean `error` state is now a **string message**:
- Shows the API's error (e.g. validation failures from the hardened endpoint) when the response has no `createConferenceFeedback`.
- Shows a generic message if the request rejects (network/server error).
- Existing required-fields validation sets the same string state.

## Testing
3 new tests (server error, generic reject error, comment-cleared-after-success). Form suite 11/11, full suite 48/48, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)