### PR TITLE
feat(post): render heading-two and add per-locale post pages

### DIFF
--- a/pages/post/[slug].js
+++ b/pages/post/[slug].js
@@ -13,12 +13,15 @@ import AdWidget from '../../components/AdWidget';
 import { getPostDetails } from '../../services';
 import AdjacentPosts from '../../sections/AdjacentPosts';
 
-function PostDetails({ post }) {
+function PostDetails({ post, locale = 'es' }) {
   const router = useRouter();
 
   if (router.isFallback) {
     return <Loader />;
   }
+
+  const localeParam = locale === 'es' ? '' : `?lang=${locale}`;
+  const ogLocale = locale === 'en' ? 'en_US' : 'es_ES';
 
   return (
     <div className="container mx-auto md:px-10 mb-8">
@@ -28,7 +31,8 @@ function PostDetails({ post }) {
         openGraph={{
           title: post.title,
           description: post.excerpt,
-          url: `https://www.sebastian-gomez.com/post/${post.slug}`,
+          url: `https://www.sebastian-gomez.com/post/${post.slug}${localeParam}`,
+          locale: ogLocale,
           type: 'article',
           article: {
             publishedTime: post.createdAt,
@@ -74,12 +78,17 @@ function PostDetails({ post }) {
 }
 export default PostDetails;
 
-// Fetch data at build time
-export async function getServerSideProps({ params }) {
-  const data = await getPostDetails(params.slug);
+// Supported content locales (must exist in Hygraph). Anything else falls back to 'es'.
+const SUPPORTED_LOCALES = ['es', 'en'];
+
+// Fetch data per request (SSR) so new posts/locales go live without a redeploy.
+export async function getServerSideProps({ params, query }) {
+  const locale = SUPPORTED_LOCALES.includes(query.lang) ? query.lang : 'es';
+  const data = await getPostDetails(params.slug, locale);
   return {
     props: {
       post: data,
+      locale,
     },
   };
 }

--- a/services/graphql/queries/getPostDetails.gql
+++ b/services/graphql/queries/getPostDetails.gql
@@ -1,5 +1,5 @@
-query GetPostDetails($slug: String!) {
-  post(where: { slug: $slug }) {
+query GetPostDetails($slug: String!, $locales: [Locale!]!) {
+  post(where: { slug: $slug }, locales: $locales) {
     title
     excerpt
     featuredImage {

--- a/services/index.js
+++ b/services/index.js
@@ -43,10 +43,14 @@ export const getCategories = async () => {
     return data.categories;
 };
 
-export const getPostDetails = async (slug) => {
+export const getPostDetails = async (slug, locale = 'es') => {
+    // Request the chosen locale, falling back to 'es' for any field without a
+    // localization (same pattern as getSite). 'es' alone keeps the default behavior.
+    const locales = locale === 'es' ? ['es'] : [locale, 'es'];
+
     const { data } = await client.query({
         query: GET_POST_DETAILS_QUERY,
-        variables: { slug },
+        variables: { slug, locales },
     });
     return data.post;
 };

--- a/services/parsing.js
+++ b/services/parsing.js
@@ -27,6 +27,14 @@ const getModifiedText = (index, text, obj) => {
   return modifiedText;
 };
 
+const HeadingTwo = memo(({ index, modifiedText }) => (
+  <h2 key={`h2-${index}`} className="text-2xl font-bold mb-4 mt-10 text-gray-800">
+    {modifiedText && modifiedText.map((item, i) => (
+      <React.Fragment key={`h2-${i}-2`}>{item}</React.Fragment>
+    ))}
+  </h2>
+));
+
 const HeadingThree = memo(({ index, modifiedText }) => (
   <h2 key={`h3-${index}`} className="text-xl font-semibold mb-4 mt-8 text-gray-800">
     {modifiedText && modifiedText.map((item, i) => (
@@ -209,6 +217,8 @@ const Iframe = memo(({ obj }) => {
 const getContentFragment = (index, text, obj, type) => {
   const modifiedText = getModifiedText(index, text, obj);
   switch (type) {
+    case 'heading-two':
+      return <HeadingTwo key={index} index={index} modifiedText={modifiedText} />;
     case 'heading-three':
       return <HeadingThree key={index} index={index} modifiedText={modifiedText} />;
     case 'paragraph':


### PR DESCRIPTION
## Summary

Two rendering/routing fixes that surfaced while publishing the English localization of the *"Construyendo un Agente de Razonamiento con Gemini y Vertex AI"* post.

### (a) `heading-two` now renders as a styled `<h2>`
`services/parsing.js` had cases for `heading-three`/`heading-four` but **none for `heading-two`** — so section headings fell through to `default` and rendered as **unstyled plain text**. This affected many existing posts, not just the new one. Added a `HeadingTwo` component + switch case.

### (b) Per-locale post pages via `?lang=`
The post page always rendered the default `es` locale because the query requested no locale. Now:
- `getPostDetails.gql` accepts `$locales`
- `getPostDetails(slug, locale)` requests `[locale, 'es']` with an `es` fallback (same pattern as the existing `getSite`)
- `pages/post/[slug].js` reads `?lang=` in `getServerSideProps`, whitelisted to `es`/`en` (invalid → `es`), and sets canonical `og:url` + `og:locale` per language

SSR, so no redeploy needed for new content/locales.

## Verification (local dev server, against live Hygraph)
| URL | Result |
|-----|--------|
| `/post/…` | Spanish — 9 styled `<h2>`, Gemini 2.5 ×5, `og:locale=es_ES` |
| `/post/…?lang=en` | English — title/body/headings in EN, `og:locale=en_US`, canonical includes `?lang=en` |
| `/post/…?lang=fr` | Falls back to Spanish |

`npx eslint` passes on all changed files (0 errors).

## Scope / not included
Minimal locale mechanism only. **No** UI language switcher, `hreflang` alternate tags, or locale-aware internal links — those are larger follow-ups if wanted.

## Notes
- The EN content itself was already published to Hygraph (the `en` localization). This PR makes it reachable on the site.
- Content-audit artifacts (`content-audit/`, `SPEC-content-audit.md`) are intentionally **not** in this PR — separate work, left uncommitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)