### PR TITLE
fix(404): return 404 (not 500) for unknown dynamic routes

### DIFF
--- a/SPEC-404-handling.md
+++ b/SPEC-404-handling.md
@@ -1,0 +1,288 @@
+# Spec: 404 Handling for Unknown Dynamic Routes
+
+> **Status:** Implemented. This is a *living* spec — update it before changing
+> behavior, not after. Companion to `SPEC.md` (conferences), which already
+> implements the correct pattern this spec generalizes.
+>
+> **Implementation note:** `getCategoryPost` is also used by the conferences page
+> for related posts, so its return shape was left untouched. Instead, the shared
+> `GetCategoryPost` query was extended to also return the `category` record, and a
+> new `getCategoryPageData(slug)` helper returns `{ category, posts }` for the
+> category page's 404-vs-empty decision. All criteria verified against a production
+> build (`npm run build && npm run start`): unknown post/category slugs and bad page
+> numbers return 404; valid pages and `?lang=en`/query params unchanged.
+
+## Objective
+
+Make dynamic SSR pages return a proper **404** (and render a helpful, custom 404
+page) when the requested identifier does not exist in the CMS, instead of crashing
+with a **500** or silently rendering an empty/misleading page.
+
+**User:** Any visitor (or crawler/bot) who hits a URL with a slug or page number
+that doesn't exist — via a typo, a stale/shared link, a mangled link, or scanning.
+
+**Why:** A non-existent post currently throws a server error. The reported symptom
+was the URL `https://www.sebastian-gomez.com/post/plugins-con-nextjs&hola=hola`.
+That URL has **no `?`**, so `&hola=hola` is part of the **slug**
+(`plugins-con-nextjs&hola=hola`), which doesn't exist in Hygraph. The bug is not
+about query parameters — it is that **an unknown slug is not handled**. A 500 is
+wrong for "not found": it looks like an outage, returns the wrong HTTP status to
+search engines, and exposes a server error instead of the branded 404 page.
+
+### Confirmed Behavior (root cause)
+
+| Route | Bad input | Current | Should be |
+|---|---|---|---|
+| `/post/[slug]` | unknown slug | **500** (crash) | **404** |
+| `/category/[slug]` | unknown slug | 200, empty page | **404** |
+| `/posts/page/[pageNumber]` | non-numeric / out-of-range | 200, empty/wrong page | **404** |
+
+Root cause for `/post/[slug]`: `getServerSideProps` calls
+`getPostDetails(slug)`; for a missing slug Hygraph returns `data.post = null`,
+which is passed straight through as the `post` prop. The component then
+dereferences `post.title` (and `post.excerpt`, `post.author`, …) during SSR →
+unhandled `TypeError` → 500.
+
+`/category/[slug]` and `/posts/page/[pageNumber]` don't crash because they map over
+an array that comes back empty — so they render a valid-looking but empty page,
+which should also be a 404 for a non-existent resource.
+
+### Reference: the correct pattern already in the repo
+
+`pages/conferences/[slug].js` already does this right — it returns
+`{ notFound: true }` from `getServerSideProps` when the CMS returns nothing. This
+spec generalizes that same pattern to the post, category, and pagination routes.
+
+### Success Criteria
+
+- `GET /post/<unknown-slug>` returns HTTP **404** and renders the custom 404 page
+  (no 500, no unhandled exception in logs).
+- `GET /post/plugins-con-nextjs&hola=hola` (the reported URL) returns **404**.
+- A **valid** post still returns 200 and renders unchanged (no regression),
+  including the `?lang=en` locale path.
+- `GET /category/<unknown-slug>` returns **404** (not a 200 empty page).
+- `GET /posts/page/<non-numeric>` and `GET /posts/page/<out-of-range>` return
+  **404** (not a 200 empty page). Page `1` and valid pages still return 200.
+- Query strings on a valid URL (`/post/<valid>?anything=x`) remain 200 — they were
+  never the cause and behavior must not change.
+- The custom 404 page shows a friendly message and surfaces **categories** and
+  **recent posts** so the visitor can recover, and these load client-side
+  (the 404 page is static — see Code Style).
+- A request to a **known category that legitimately has zero posts** returns **200**
+  and renders an empty-state message ("aún no hay posts" / recommended content) —
+  it is NOT a 404.
+- A genuine CMS/network failure (Hygraph timeout, auth, 5xx) still returns **500** —
+  it is NOT masked as a 404.
+
+## Tech Stack
+
+- **Framework:** Next.js 16 (Pages Router), React 19
+- **Data fetching:** Apollo Client reads via `services/index.js`
+- **CMS:** Hygraph (GraphQL) — returns `null` / empty arrays for missing records
+- **404 page:** Next.js default `/404` (static, already built — see build output)
+- **Testing:** Jest + React Testing Library (unit), Cypress (e2e)
+
+## Commands
+
+```
+Dev:   npm run dev
+Build: npm run build
+Start: npm run start
+Lint:  npm run lint            # eslint .  (autofix: npx eslint . --fix)
+Test:  npm test                # jest
+E2E:   npm run cypress:run
+```
+
+Manual repro (against a local prod build, since dev can mask SSR 500s):
+
+```
+npm run build && npm run start
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3000/post/does-not-exist-xyz
+# expected after fix: 404   (currently: 500)
+```
+
+## Project Structure
+
+```
+pages/post/[slug].js                → SSR post page  (PRIMARY fix — currently 500s)
+pages/category/[slug].js            → SSR category page (return 404 on empty)
+pages/posts/page/[pageNumber].js    → SSR pagination (return 404 on bad/empty page)
+pages/conferences/[slug].js         → REFERENCE: already returns notFound correctly
+services/index.js                   → getPostDetails / getCategoryPost / getPostsPerPage
+__tests__/pages/                     → getServerSideProps unit tests (new)
+cypress/e2e/                         → e2e: unknown slug → 404 (new/extended)
+```
+
+## Code Style
+
+Match the existing codebase. The guard lives in `getServerSideProps` — return
+`{ notFound: true }` so Next.js serves the 404 page with the correct status. Do
+**not** add defensive `post?.title` checks in the component to paper over a null
+prop; the page should never receive a null record.
+
+```js
+// pages/post/[slug].js — getServerSideProps
+export async function getServerSideProps({ params, query }) {
+  const locale = SUPPORTED_LOCALES.includes(query.lang) ? query.lang : 'es';
+  const data = await getPostDetails(params.slug, locale);
+
+  if (!data) {
+    return { notFound: true };          // unknown slug → 404, not a 500
+  }
+
+  return { props: { post: data, locale } };
+}
+```
+
+**Custom 404 page (`pages/404.js`).** In the Pages Router, `404.js` is **statically
+generated** — it CANNOT use `getServerSideProps`/`getStaticProps` to fetch data per
+request. So its recovery content (categories + recent posts) must load
+**client-side**, the same way the existing widgets already do:
+
+```jsx
+// pages/404.js — static page; data loads client-side via existing components
+export default function Custom404() {
+  return (
+    <div className="container mx-auto px-4 md:px-10 my-12 text-center">
+      <h1 className="text-3xl font-semibold mb-4">Página no encontrada</h1>
+      <p className="mb-8 text-gray-600">
+        Parece que lo que buscas no existe. Quizá quieras revisar las categorías
+        o los posts recientes.
+      </p>
+      <div className="max-w-xl mx-auto text-left">
+        <PostWidget categories={undefined} slug={undefined} />  {/* recent posts */}
+        <Categories />                                          {/* categories   */}
+      </div>
+    </div>
+  );
+}
+```
+
+`Categories` and `PostWidget` already fetch on the client (see `pages/index.js`
+sidebar), so they work inside a static 404 page unchanged. All copy stays in
+**Spanish**.
+
+**Distinguish "not found" from "fetch failed" (Open Question 2 → resolved: yes).**
+A successful CMS response with no record is a 404; a transport/CMS error is a real
+500 and must not be masked. Reads in `services/index.js` may throw on network/auth
+errors — let those propagate (→ 500). Only return `notFound` when the query
+**succeeded** and the record is absent (`data.post == null` / empty list).
+
+**Conventions:**
+
+- 2-space indent in pages/components; 4-space in `services/` (follow the file).
+- Guard in `getServerSideProps`, not in the render body.
+- `/category/[slug]`: an empty result for an **unknown** slug is a **404**; a
+  **known** category with zero posts renders a **200 empty state** ("aún no hay
+  posts" + recommended content). This requires the query to tell the two apart —
+  see Open Question 1 (resolved) and Tasks.
+- For `/posts/page/[pageNumber]`: reject non-numeric and `< 1` page numbers, and
+  page numbers past the last page, with `notFound`.
+
+## Testing Strategy
+
+- **Framework:** Jest + React Testing Library (unit); Cypress (e2e).
+- **Location:** Unit tests under `__tests__/` mirroring source paths.
+- **Coverage target:** 90% for new/changed code (per project DAD config).
+- **What to test (unit — `getServerSideProps`):**
+  - `/post/[slug]`: returns `{ notFound: true }` when `getPostDetails` resolves
+    `null`/`undefined`; returns `{ props: { post, locale } }` for a found post;
+    `?lang=en` selects the `en` locale, unknown `lang` falls back to `es`.
+  - `/category/[slug]`: `{ notFound: true }` when `getCategoryPost` is empty;
+    props when non-empty.
+  - `/posts/page/[pageNumber]`: `{ notFound: true }` for non-numeric and
+    out-of-range page numbers; props for valid pages.
+  - Mock the `services` module so no live CMS calls are made.
+- **What to test (e2e — Cypress):**
+  - Visit an unknown post slug → assert the 404 page is shown (e.g. the 404 marker
+    text) and the app did not error. Stub `services`/network as needed.
+  - Visit a known slug → assert the post renders (regression guard).
+
+## Boundaries
+
+- **Always:**
+  - Run `npm run lint` and `npm test` before committing.
+  - Use `{ notFound: true }` from `getServerSideProps` for missing resources.
+  - Verify the fix against a **production build** (`npm run build && npm run start`),
+    since `npm run dev` can render an error overlay instead of a clean 500/404.
+  - Keep the valid-post happy path (incl. `?lang=en`) unchanged.
+- **Ask first:**
+  - Treating a *known but empty* category as 404 vs. rendering an "empty" state.
+  - Adding a custom-styled 404 page (vs. Next.js default) — that's a separate change.
+  - Any change to the Hygraph schema or `services` query shapes.
+  - Switching these pages off SSR.
+- **Never:**
+  - "Fix" this by mangling/stripping the slug or query string — the slug genuinely
+    doesn't exist; parsing is not the bug.
+  - Swallow real CMS/network errors as 404. A failed request (timeout, auth, 5xx
+    from Hygraph) is a genuine 500 — only a successful "no such record" is a 404.
+    (See Open Questions: distinguish "not found" from "fetch failed".)
+  - Remove or skip failing tests without approval.
+  - Commit secrets or `.env`.
+
+## Tasks
+
+- [ ] **Task: Return 404 for unknown post slug** *(primary — fixes the 500)*
+  - Acceptance: `getServerSideProps` returns `{ notFound: true }` when
+    `getPostDetails` returns null. Valid slug + `?lang=en` unchanged.
+  - Verify: `npm run build && npm run start`; `curl` of an unknown slug → 404,
+    valid slug → 200. Jest unit test green.
+  - Files: `pages/post/[slug].js`, `__tests__/pages/post.test.js`.
+
+- [ ] **Task: Distinguish unknown category from empty category (query change)**
+  - Context: `GetCategoryPost` currently returns only `postsConnection.edges` and
+    never queries the `Category` model, so "unknown slug" and "known slug, zero
+    posts" are indistinguishable (both empty). To satisfy decision (a) we must know
+    whether the category exists.
+  - Acceptance: extend the GraphQL query to also fetch the category record (e.g.
+    `category(where: { slug: $slug }) { name slug }`) and surface it from
+    `getCategoryPost` (return both `category` and `edges`, e.g.
+    `{ category, posts }`). **Ask-first** boundary: this touches a query shape —
+    confirm before changing.
+  - Verify: query returns `category: null` for an unknown slug and a populated
+    object for a known one. Unit test on the service.
+  - Files: `services/graphql/queries/getCategoryPost.gql`, `services/index.js`,
+    `__tests__/services/...`.
+
+- [ ] **Task: 404 for unknown category; empty-state for known-but-empty category**
+  - Acceptance: in `getServerSideProps`, if `category == null` → `{ notFound: true }`
+    (404). If the category exists but has zero posts → return props and render a
+    **200 empty state** in Spanish ("Aún no hay posts en esta categoría" +
+    recommended content / categories). Non-empty → renders as today.
+  - Verify: `curl` unknown category → 404; known empty category → 200 empty state;
+    known non-empty category → 200 list. Unit + component test.
+  - Files: `pages/category/[slug].js`, `__tests__/pages/category.test.js`.
+
+- [ ] **Task: Return 404 for invalid/out-of-range page number**
+  - Acceptance: non-numeric or out-of-range `pageNumber` → `{ notFound: true }`;
+    valid pages → 200.
+  - Verify: `curl /posts/page/abc` and a too-large page → 404; `/posts/page/1` →
+    200. Unit test.
+  - Files: `pages/posts/page/[pageNumber].js`, `__tests__/pages/page.test.js`.
+
+- [ ] **Task: Build the custom 404 page**
+  - Acceptance: `pages/404.js` shows a friendly Spanish message ("Parece que lo que
+    buscas no existe. Quizá quieras revisar las categorías o los posts recientes.")
+    and renders **recent posts** + **categories** via the existing client-fetching
+    components (`PostWidget`, `Categories`). No `getServerSideProps`/`getStaticProps`
+    (the page is static; data loads client-side). Styling matches the site (Tailwind).
+  - Verify: `npm run build && npm run start`; visit an unknown slug → 404 page shows
+    message + categories + recent posts. Component test renders without crashing.
+  - Files: `pages/404.js`, `__tests__/pages/404.test.js`.
+
+- [ ] **Task: e2e — unknown slug renders custom 404**
+  - Acceptance: Cypress visits an unknown post slug and asserts the custom 404 page
+    (message + categories/recent-posts present); a known slug still renders.
+  - Verify: `npm run cypress:run`.
+  - Files: `cypress/e2e/...`.
+
+## Resolved Decisions
+
+1. **Known-but-empty category → 200 empty state**, not 404. Render a Spanish
+   "aún no hay posts" message plus recommended content. Requires the category query
+   to distinguish unknown-slug from zero-posts (see Tasks).
+2. **"Not found" vs "fetch failed" → keep them separate.** Only a *successful*
+   query with no record returns `notFound`; transport/CMS errors still surface as
+   500 and must not be masked as 404.
+3. **Custom 404 page → yes, in scope.** Friendly Spanish copy plus categories and
+   recent posts so visitors can recover (client-side data, since `404.js` is static).

--- a/__tests__/pages/404.test.js
+++ b/__tests__/pages/404.test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Custom404 from '../../pages/404';
+
+// The 404 page renders PostWidget + Categories, which fetch client-side. Stub the
+// services so the page renders without hitting a real CMS.
+jest.mock('../../services', () => ({
+  getRecentPosts: jest.fn().mockResolvedValue([]),
+  getSimilarPosts: jest.fn().mockResolvedValue([]),
+  getCategories: jest.fn().mockResolvedValue([]),
+}));
+jest.mock('next/link', () => ({ children, href }) => <a href={href}>{children}</a>);
+
+describe('Custom404', () => {
+  it('renders a friendly Spanish message and a home link', () => {
+    render(<Custom404 />);
+
+    expect(screen.getByText('Página no encontrada')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Quizá quieras revisar las categorías o los posts recientes/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Ir al inicio')).toBeInTheDocument();
+  });
+});

--- a/__tests__/pages/category.test.js
+++ b/__tests__/pages/category.test.js
@@ -1,0 +1,39 @@
+// Unit-tests the category page's getServerSideProps: unknown slug -> 404,
+// known-but-empty -> 200 props with empty posts, populated -> 200 props.
+jest.mock('../../services', () => ({
+  getCategoryPageData: jest.fn(),
+}));
+
+import { getCategoryPageData } from '../../services';
+import { getServerSideProps } from '../../pages/category/[slug]';
+
+describe('category/[slug] getServerSideProps', () => {
+  beforeEach(() => getCategoryPageData.mockReset());
+
+  it('returns notFound when the category does not exist', async () => {
+    getCategoryPageData.mockResolvedValue({ category: null, posts: [] });
+
+    const result = await getServerSideProps({ params: { slug: 'nope' } });
+
+    expect(result).toEqual({ notFound: true });
+  });
+
+  it('returns props with empty posts for a known category with no posts', async () => {
+    const category = { name: 'Empty', slug: 'empty' };
+    getCategoryPageData.mockResolvedValue({ category, posts: [] });
+
+    const result = await getServerSideProps({ params: { slug: 'empty' } });
+
+    expect(result).toEqual({ props: { category, posts: [] } });
+  });
+
+  it('returns props with posts for a populated category', async () => {
+    const category = { name: 'React', slug: 'react' };
+    const posts = [{ node: { slug: 'a' } }];
+    getCategoryPageData.mockResolvedValue({ category, posts });
+
+    const result = await getServerSideProps({ params: { slug: 'react' } });
+
+    expect(result).toEqual({ props: { category, posts } });
+  });
+});

--- a/__tests__/pages/page.test.js
+++ b/__tests__/pages/page.test.js
@@ -1,0 +1,52 @@
+// Unit-tests pagination getServerSideProps: invalid/out-of-range page -> 404,
+// valid page -> props.
+jest.mock('../../services', () => ({
+  getPostsPerPage: jest.fn(),
+  getPosts: jest.fn(),
+  getSite: jest.fn(),
+}));
+
+import { getPostsPerPage, getPosts, getSite } from '../../services';
+import { getServerSideProps } from '../../pages/posts/page/[pageNumber]';
+
+describe('posts/page/[pageNumber] getServerSideProps', () => {
+  beforeEach(() => {
+    getPostsPerPage.mockReset();
+    getPosts.mockReset();
+    getSite.mockReset();
+    getPosts.mockResolvedValue(Array.from({ length: 8 }, (_, i) => ({ id: i })));
+    getSite.mockResolvedValue({});
+  });
+
+  it('returns notFound for a non-numeric page number', async () => {
+    const result = await getServerSideProps({ params: { pageNumber: 'abc' } });
+    expect(result).toEqual({ notFound: true });
+    expect(getPostsPerPage).not.toHaveBeenCalled();
+  });
+
+  it('returns notFound for a page number below 1', async () => {
+    const result = await getServerSideProps({ params: { pageNumber: '0' } });
+    expect(result).toEqual({ notFound: true });
+  });
+
+  it('returns notFound for an out-of-range page (empty beyond page 1)', async () => {
+    getPostsPerPage.mockResolvedValue([]);
+    const result = await getServerSideProps({ params: { pageNumber: '99' } });
+    expect(result).toEqual({ notFound: true });
+  });
+
+  it('returns props for a valid page with posts', async () => {
+    const posts = [{ node: { slug: 'a' } }];
+    getPostsPerPage.mockResolvedValue(posts);
+    const result = await getServerSideProps({ params: { pageNumber: '2' } });
+    expect(result.props.posts).toEqual(posts);
+    expect(result.notFound).toBeUndefined();
+  });
+
+  it('renders page 1 even when empty (not a 404)', async () => {
+    getPostsPerPage.mockResolvedValue([]);
+    const result = await getServerSideProps({ params: { pageNumber: '1' } });
+    expect(result.notFound).toBeUndefined();
+    expect(result.props.posts).toEqual([]);
+  });
+});

--- a/__tests__/pages/post.test.js
+++ b/__tests__/pages/post.test.js
@@ -1,0 +1,47 @@
+// Unit-tests the post page's getServerSideProps: unknown slug -> 404,
+// found post -> props, and locale selection via ?lang.
+jest.mock('../../services', () => ({
+  getPostDetails: jest.fn(),
+}));
+
+import { getPostDetails } from '../../services';
+import { getServerSideProps } from '../../pages/post/[slug]';
+
+describe('post/[slug] getServerSideProps', () => {
+  beforeEach(() => getPostDetails.mockReset());
+
+  it('returns notFound when the post does not exist', async () => {
+    getPostDetails.mockResolvedValue(null);
+
+    const result = await getServerSideProps({ params: { slug: 'nope' }, query: {} });
+
+    expect(result).toEqual({ notFound: true });
+  });
+
+  it('returns the post as props when found (default es locale)', async () => {
+    const post = { slug: 'hello', title: 'Hola' };
+    getPostDetails.mockResolvedValue(post);
+
+    const result = await getServerSideProps({ params: { slug: 'hello' }, query: {} });
+
+    expect(result).toEqual({ props: { post, locale: 'es' } });
+    expect(getPostDetails).toHaveBeenCalledWith('hello', 'es');
+  });
+
+  it('uses ?lang=en when supported', async () => {
+    getPostDetails.mockResolvedValue({ slug: 'hello', title: 'Hi' });
+
+    const result = await getServerSideProps({ params: { slug: 'hello' }, query: { lang: 'en' } });
+
+    expect(result.props.locale).toBe('en');
+    expect(getPostDetails).toHaveBeenCalledWith('hello', 'en');
+  });
+
+  it('falls back to es for an unsupported lang', async () => {
+    getPostDetails.mockResolvedValue({ slug: 'hello', title: 'Hola' });
+
+    const result = await getServerSideProps({ params: { slug: 'hello' }, query: { lang: 'fr' } });
+
+    expect(result.props.locale).toBe('es');
+  });
+});

--- a/__tests__/services/index.test.js
+++ b/__tests__/services/index.test.js
@@ -6,7 +6,7 @@ jest.mock('@apollo/client', () => ({
   HttpLink: jest.fn(),
 }));
 
-import { getConferenceDetails, submitConferenceFeedback } from '../../services';
+import { getConferenceDetails, submitConferenceFeedback, getCategoryPageData } from '../../services';
 
 describe('getConferenceDetails', () => {
   beforeEach(() => mockQuery.mockReset());
@@ -21,6 +21,37 @@ describe('getConferenceDetails', () => {
     expect(mockQuery).toHaveBeenCalledWith(
       expect.objectContaining({ variables: { slug: 'react-conf' } }),
     );
+  });
+});
+
+describe('getCategoryPageData', () => {
+  beforeEach(() => mockQuery.mockReset());
+
+  it('returns the category and its posts when the category exists', async () => {
+    const category = { name: 'React', slug: 'react' };
+    const edges = [{ node: { slug: 'a' } }];
+    mockQuery.mockResolvedValue({ data: { category, postsConnection: { edges } } });
+
+    const result = await getCategoryPageData('react');
+
+    expect(result).toEqual({ category, posts: edges });
+  });
+
+  it('returns category: null for an unknown slug', async () => {
+    mockQuery.mockResolvedValue({ data: { category: null, postsConnection: { edges: [] } } });
+
+    const result = await getCategoryPageData('nope');
+
+    expect(result).toEqual({ category: null, posts: [] });
+  });
+
+  it('returns the category with empty posts when it has none', async () => {
+    const category = { name: 'Empty', slug: 'empty' };
+    mockQuery.mockResolvedValue({ data: { category, postsConnection: { edges: [] } } });
+
+    const result = await getCategoryPageData('empty');
+
+    expect(result).toEqual({ category, posts: [] });
   });
 });
 

--- a/cypress/e2e/not-found.spec.cy.js
+++ b/cypress/e2e/not-found.spec.cy.js
@@ -1,0 +1,41 @@
+describe('Unknown slug renders the custom 404 page', () => {
+  it('shows the custom 404 page (not a 500) for an unknown post slug', () => {
+    // failOnStatusCode:false so the 404 response doesn't abort the test; we assert
+    // the custom 404 content rendered (message + recovery widgets) instead of a 500.
+    cy.visit('/post/this-post-does-not-exist-xyz', { failOnStatusCode: false });
+
+    cy.contains('Página no encontrada').should('be.visible');
+    cy.contains(/revisar las categorías o los posts recientes/i).should('exist');
+    cy.contains('Recent Posts').should('exist'); // PostWidget recovery section
+  });
+
+  it('still renders a real post page (regression guard)', () => {
+    const graphqlAPI = Cypress.env('NEXT_PUBLIC_GRAPHCMS_ENDPOINT');
+    if (!graphqlAPI) {
+      throw new Error('NEXT_PUBLIC_GRAPHCMS_ENDPOINT is not defined for Cypress');
+    }
+
+    cy.request({
+      method: 'POST',
+      url: graphqlAPI,
+      timeout: 30000,
+      body: {
+        query: `
+          query GetPosts {
+            posts(orderBy: createdAt_ASC) {
+              slug
+            }
+          }
+        `,
+      },
+    }).then((response) => {
+      expect(response.status, 'CMS responded 200').to.eq(200);
+      const { posts } = response.body.data;
+      expect(posts, 'CMS returned posts').to.have.length.greaterThan(0);
+
+      cy.visit(`/post/${posts[0].slug}`);
+      cy.get('h1', { timeout: 15000 }).should('exist');
+      cy.contains('Página no encontrada').should('not.exist');
+    });
+  });
+});

--- a/pages/404.js
+++ b/pages/404.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import Link from 'next/link';
+import Head from 'next/head';
+import { Categories, PostWidget } from '../components';
+
+// Custom 404. In the Pages Router this page is statically generated, so it cannot
+// fetch data per request — the recovery content (recent posts + categories) loads
+// client-side via the existing components (same as the homepage sidebar).
+export default function Custom404() {
+  return (
+    <div className="container mx-auto sm:px-4 md:px-10 mb-8">
+      <Head>
+        <title>Página no encontrada</title>
+        <meta name="robots" content="noindex" />
+      </Head>
+      <div className="bg-white shadow-lg rounded-lg p-8 mb-8 text-center">
+        <h1 className="text-4xl font-bold mb-4">Página no encontrada</h1>
+        <p className="text-lg text-gray-600 mb-6">
+          Parece que lo que buscas no existe. Quizá quieras revisar las categorías
+          o los posts recientes.
+        </p>
+        <Link href="/">
+          <span className="transition duration-500 ease transform hover:-translate-y-1 inline-block bg-pink-600 text-lg font-medium rounded-full text-white px-6 py-3 cursor-pointer">
+            Ir al inicio
+          </span>
+        </Link>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-12">
+        <div className="lg:col-span-8 col-span-1">
+          <PostWidget categories={undefined} slug={undefined} />
+        </div>
+        <div className="lg:col-span-4 col-span-1">
+          <div className="lg:sticky relative top-8">
+            <Categories />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/pages/404.js
+++ b/pages/404.js
@@ -19,10 +19,8 @@ export default function Custom404() {
           Parece que lo que buscas no existe. Quizá quieras revisar las categorías
           o los posts recientes.
         </p>
-        <Link href="/">
-          <span className="transition duration-500 ease transform hover:-translate-y-1 inline-block bg-pink-600 text-lg font-medium rounded-full text-white px-6 py-3 cursor-pointer">
-            Ir al inicio
-          </span>
+        <Link href="/" className="transition duration-500 ease transform hover:-translate-y-1 inline-block bg-pink-600 text-lg font-medium rounded-full text-white px-6 py-3 cursor-pointer">
+          Ir al inicio
         </Link>
       </div>
 

--- a/pages/category/[slug].js
+++ b/pages/category/[slug].js
@@ -2,31 +2,42 @@ import React from 'react';
 import { useRouter } from 'next/router';
 
 import Head from 'next/head';
-import { getCategoryPost } from '../../services';
+import { getCategoryPageData } from '../../services';
 import { PostCard, Categories, Loader, AdWidget } from '../../components';
 
-function CategoryPost({ posts }) {
+function CategoryPost({ category, posts }) {
   const router = useRouter();
 
   if (router.isFallback) {
     return <Loader />;
   }
 
+  const title = category ? `Posts de ${category.name}` : 'Posts por categoría';
+
   return (
     <div className="container mx-auto px-10 mb-8">
       <Head>
-        <title>Posts por categoría</title>
+        <title>{title}</title>
         <meta
           property="og:title"
-          content="Posts por categoría"
+          content={title}
           key="title"
         />
       </Head>
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-12">
         <div className="col-span-1 lg:col-span-8">
-          {posts.map((post, index) => (
-            <PostCard key={index} post={post.node} />
-          ))}
+          {posts.length === 0 ? (
+            <div className="bg-white shadow-lg rounded-lg p-8 text-center">
+              <h2 className="text-xl font-semibold mb-2">Aún no hay posts en esta categoría</h2>
+              <p className="text-gray-600">
+                Mientras tanto, revisa otras categorías o los posts recientes.
+              </p>
+            </div>
+          ) : (
+            posts.map((post, index) => (
+              <PostCard key={index} post={post.node} />
+            ))
+          )}
         </div>
         <div className="col-span-1 lg:col-span-4">
           <div className="relative lg:sticky top-8">
@@ -40,11 +51,16 @@ function CategoryPost({ posts }) {
 }
 export default CategoryPost;
 
-// Fetch data at build time
+// Fetch data per request (SSR). An unknown category slug => 404; a known category
+// with zero posts => 200 with an empty state (see SPEC-404-handling.md).
 export async function getServerSideProps({ params }) {
-  const posts = await getCategoryPost(params.slug);
+  const { category, posts } = await getCategoryPageData(params.slug);
+
+  if (!category) {
+    return { notFound: true };
+  }
 
   return {
-    props: { posts },
+    props: { category, posts },
   };
 }

--- a/pages/post/[slug].js
+++ b/pages/post/[slug].js
@@ -85,6 +85,13 @@ const SUPPORTED_LOCALES = ['es', 'en'];
 export async function getServerSideProps({ params, query }) {
   const locale = SUPPORTED_LOCALES.includes(query.lang) ? query.lang : 'es';
   const data = await getPostDetails(params.slug, locale);
+
+  // A successful query with no record => the slug doesn't exist => 404 (not a 500).
+  // A transport/CMS error throws above and surfaces as a genuine 500 (not masked).
+  if (!data) {
+    return { notFound: true };
+  }
+
   return {
     props: {
       post: data,

--- a/pages/posts/page/[pageNumber].js
+++ b/pages/posts/page/[pageNumber].js
@@ -55,15 +55,25 @@ export default function Home({ posts, site, nextPageNumber }) {
   );
 }
 
-// Fetch data at build time
+// Fetch data per request (SSR). A non-numeric or < 1 page number, or a page past
+// the last one, returns 404 (see SPEC-404-handling.md). Page 1 always renders.
 export async function getServerSideProps({ params }) {
-  const posts = (await getPostsPerPage(params.pageNumber)) || [];
+  const pageNumber = Number(params.pageNumber);
+  if (!Number.isInteger(pageNumber) || pageNumber < 1) {
+    return { notFound: true };
+  }
+
+  const posts = (await getPostsPerPage(pageNumber)) || [];
+
+  // Out of range: no posts on a page beyond the first => 404 (page 1 may be empty).
+  if (posts.length === 0 && pageNumber > 1) {
+    return { notFound: true };
+  }
+
   const postsCount = (await getPosts()) || [];
   const site = (await getSite()) || [];
   const nextPageNumber =
-    postsCount.length > parseInt(params.pageNumber || '1', 10) * 4
-      ? parseInt(params.pageNumber, 10) + 1
-      : 0;
+    postsCount.length > pageNumber * 4 ? pageNumber + 1 : 0;
   return {
     props: {
       posts,

--- a/services/graphql/queries/getCategoryPost.gql
+++ b/services/graphql/queries/getCategoryPost.gql
@@ -1,4 +1,8 @@
 query GetCategoryPost($slug: String!) {
+  category(where: { slug: $slug }) {
+    name
+    slug
+  }
   postsConnection(where: { categories_some: { slug: $slug } }) {
     edges {
       cursor

--- a/services/index.js
+++ b/services/index.js
@@ -79,6 +79,20 @@ export const getCategoryPost = async (slug) => {
     return data.postsConnection.edges;
 };
 
+// Like getCategoryPost, but also returns the category record so callers can tell
+// "unknown category" (category === null => 404) apart from "known category, zero
+// posts" (category set, empty posts => 200 empty state). Same single query.
+export const getCategoryPageData = async (slug) => {
+    const { data } = await client.query({
+        query: GET_CATEGORY_POST_QUERY,
+        variables: { slug },
+    });
+    return {
+        category: data.category || null,
+        posts: data.postsConnection.edges,
+    };
+};
+
 export const getFeaturedPosts = async () => {
     const { data } = await client.query({ query: GET_FEATURED_POSTS_QUERY });
     return data.posts;

--- a/services/index.js
+++ b/services/index.js
@@ -88,8 +88,8 @@ export const getCategoryPageData = async (slug) => {
         variables: { slug },
     });
     return {
-        category: data.category || null,
-        posts: data.postsConnection.edges,
+        category: data?.category || null,
+        posts: data?.postsConnection?.edges || [],
     };
 };
 


### PR DESCRIPTION
## Problem

Unknown post slugs crashed with **HTTP 500** instead of returning a 404. The reported URL `https://www.sebastian-gomez.com/post/plugins-con-nextjs&hola=hola` has **no `?`**, so the trailing `&hola=hola` was part of the (non-existent) **slug** — query parameters were never the cause.

**Root cause:** `getServerSideProps` in `pages/post/[slug].js` passed Hygraph's `null` straight through as the `post` prop; the component then dereferenced `post.title` during SSR → unhandled exception → 500. Two sibling routes silently rendered empty/misleading 200 pages for unknown identifiers.

## Changes

- **`pages/post/[slug].js`** — return `notFound: true` when the post is null → **404, not 500**
- **`pages/category/[slug].js`** — **404** for an unknown category; **200 empty-state** ("Aún no hay posts…") for a known category with zero posts
- **`services/`** — extend `GetCategoryPost` to also fetch the `category` record; add `getCategoryPageData()` returning `{ category, posts }`. `getCategoryPost` is left intact since the conferences page depends on its shape
- **`pages/posts/page/[pageNumber].js`** — **404** for non-numeric, `< 1`, or out-of-range page numbers (page 1 still renders even when empty)
- **`pages/404.js`** — new custom 404 with a friendly Spanish message plus client-loaded recent posts and categories so visitors can recover

Real CMS/network errors still surface as a genuine **500** (not masked as 404).

## Verification

Against a production build (`npm run build && npm run start`):

| URL | Before | After |
|---|---|---|
| `/post/<valid>` | 200 | 200 |
| `/post/does-not-exist` | **500** | **404** |
| `/post/plugins-con-nextjs&hola=hola` (reported) | **500** | **404** |
| `/post/<valid>?hola=error` / `?lang=en` | 200 | 200 |
| `/posts/page/abc` · `/0` · `/9999` | 200 | **404** |
| `/category/<unknown>` | 200 | **404** |

- `npm test` → **79/79 pass** (new unit tests for each `getServerSideProps` + `getCategoryPageData`; custom-404 render test)
- `npm run lint` → **0 errors**
- Cypress e2e (`cypress/e2e/not-found.spec.cy.js`) asserts the custom 404 renders and a real post still loads

Full spec: `SPEC-404-handling.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)