### PR TITLE
refactor(about): numeric Image dimensions, drop redundant sizes on flags

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -24,9 +24,8 @@ export default function About({ site }) {
               <Image
                 unoptimized
                 alt="English"
-                height="32"
-                sizes="(max-width: 768px) 100vw"
-                width="32"
+                height={32}
+                width={32}
                 className="align-middle rounded-full"
                 src="/en.png"
               />

--- a/pages/en/about.js
+++ b/pages/en/about.js
@@ -20,9 +20,8 @@ export default function About({ site }) {
               <Image
                 unoptimized
                 alt="Español"
-                height="32"
-                width="32"
-                sizes="(max-width: 768px) 100vw"
+                height={32}
+                width={32}
                 className="align-middle rounded-full"
                 src="/es.jpg"
               />


### PR DESCRIPTION
## What

Cleans up the language-flag `<Image>` props on both about pages:
- `width`/`height` passed as **numbers** instead of strings (Next.js typing)
- Removed the redundant `sizes="(max-width: 768px) 100vw"` prop

## Why

For a fixed 32×32 `unoptimized` icon, `sizes` has no effect — no `srcSet` is generated — and `100vw` would mislead the browser into fetching a full-width image on mobile for a 32px icon if optimization were ever re-enabled.

This is the same fix applied to the new `PostLanguageToggle` component in #16 (review feedback); applying it to the pre-existing about-page flags it was copied from.

## Verification

- `npm run lint` → 0 errors
- `npm run build` → compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)